### PR TITLE
Add django auto field to settings.py

### DIFF
--- a/gastitis/settings.py
+++ b/gastitis/settings.py
@@ -145,4 +145,8 @@ SITE_DOMAIN = 'http://127.0.0.1:8000'
 # Telegram Settings
 BOT_TOKEN = TELEGRAM_BOT_TOKEN
 
+# Default auto field for django id
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 print(f"Connecting to database {DATABASES['default']['NAME']}" )
+


### PR DESCRIPTION
## Detall

Al migrar reporta los warnings de que no tiene definido **AutoField** ni en el settings ni en los apps.py

![Screenshot from 2025-03-22 12-14-42](https://github.com/user-attachments/assets/2298be05-4cb1-42f5-94b5-c6269c7c9eb3)
