### PR TITLE
New `exportar_mes` command

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -11,6 +11,7 @@ from bot.utils import (
     get_month_expenses,
     get_month_and_year,
     is_group,
+    get_month_filters,
     new_expense,
     new_payment,
     show_expenses,
@@ -97,6 +98,18 @@ async def export(update, context, user, group):
     )
 
 
+@user_and_group
+async def export_month(update, context, user, group):
+    month, year = get_month_and_year(context.args)
+    expense_filters = get_month_filters(year, month)
+    extra_name = f"{year}-{month}"
+    exporter = ExportExpenses(user, group, extra_name, **expense_filters)
+    text = await exporter.run()
+    await context.bot.send_message(
+        chat_id=update.message.chat_id, text=text, parse_mode=ParseMode.MARKDOWN
+    )
+
+
 async def vianda(update, context):
     vianda_message = ViandaMessage(*context.args)
 
@@ -125,6 +138,7 @@ HANDLERS = [
     CommandHandler('asado', calc_asado),
     CommandHandler('a', calc_asado),
     CommandHandler('exportar', export),
+    CommandHandler('exportar_mes', export_month),
     CommandHandler('vianda', vianda),
     MessageHandler(filters.COMMAND, unknown),
 ]

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -103,7 +103,7 @@ async def export_month(update, context, user, group):
     month, year = get_month_and_year(context.args)
     expense_filters = get_month_filters(year, month)
     extra_name = f"{year}-{month}"
-    exporter = ExportExpenses(user, group, extra_name, **expense_filters)
+    exporter = ExportExpenses(user, group, extra_name, expense_filters)
     text = await exporter.run()
     await context.bot.send_message(
         chat_id=update.message.chat_id, text=text, parse_mode=ParseMode.MARKDOWN

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -329,7 +329,7 @@ async def show_expenses(group, **expense_filters):
     return text
 
 
-async def get_month_expenses(group, year, month):
+def get_month_filters(year, month):
     first_day_of_month = dt.date(year, month, 1)
     if month == 12:
         next_month = 1
@@ -342,6 +342,11 @@ async def get_month_expenses(group, year, month):
         'date__gte': first_day_of_month,
         'date__lt': first_day_of_next_month,
     }
+    return expense_filters
+
+
+async def get_month_expenses(group, year, month):
+    expense_filters = get_month_filters(year, month)
     text = "Gastos del mes {} del año {}\n\n".format(month, year)
     text += await show_expenses(group, **expense_filters)
     return text

--- a/use_cases/export.py
+++ b/use_cases/export.py
@@ -19,10 +19,10 @@ def only_beta_users(username):
 
 class ExportExpenses:
 
-    def __init__(self, user, group, extra_name, **expense_filters):
+    def __init__(self, user, group, extra_name=None, expense_filters=None):
         self.user = user
         self.group = group
-        self.expense_filters = expense_filters
+        self.expense_filters = expense_filters if expense_filters is not None else {}
         self.extra_name = extra_name
 
     async def get_expenses(self):
@@ -93,8 +93,10 @@ class ExportExpenses:
     def get_sheet_url_and_name(self):
         # TODO: save urls in db by group
         url = "https://docs.google.com/spreadsheets/d/1YimK1TlwjzfbCPZIxrTVsNJAhbhe4RnFmvibdkJLvzg/edit?gid=1350094138#gid=1350094138"
-
-        name = f"{self.group.name}@{self.extra_name}"
+        
+        name = self.group.name
+        if self.extra_name:
+            name += f"@{self.extra_name}"
 
         return url, name
 

--- a/use_cases/export.py
+++ b/use_cases/export.py
@@ -19,10 +19,11 @@ def only_beta_users(username):
 
 class ExportExpenses:
 
-    def __init__(self, user, group, **expense_filters):
+    def __init__(self, user, group, extra_name, **expense_filters):
         self.user = user
         self.group = group
         self.expense_filters = expense_filters
+        self.extra_name = extra_name
 
     async def get_expenses(self):
         """
@@ -93,7 +94,7 @@ class ExportExpenses:
         # TODO: save urls in db by group
         url = "https://docs.google.com/spreadsheets/d/1YimK1TlwjzfbCPZIxrTVsNJAhbhe4RnFmvibdkJLvzg/edit?gid=1350094138#gid=1350094138"
 
-        name = self.group.name
+        name = f"{self.group.name}@{self.extra_name}"
 
         return url, name
 
@@ -123,4 +124,3 @@ class ExportExpenses:
         text += f"- Nombre de la nueva pestaña: *\"{worksheet_name}\"*."
 
         return text
-

--- a/use_cases/export.py
+++ b/use_cases/export.py
@@ -93,7 +93,7 @@ class ExportExpenses:
     def get_sheet_url_and_name(self):
         # TODO: save urls in db by group
         url = "https://docs.google.com/spreadsheets/d/1YimK1TlwjzfbCPZIxrTVsNJAhbhe4RnFmvibdkJLvzg/edit?gid=1350094138#gid=1350094138"
-        
+
         name = self.group.name
         if self.extra_name:
             name += f"@{self.extra_name}"


### PR DESCRIPTION
Implementa el ticket [#35](https://github.com/sofide/gastitis/issues/35). 
No le agregué el texto en el help, porque aún no está el de exportar plano, y este sería "Igual al /exportar pero toma el mes y año opcionales como argumentos (default año y mes actuales) el formato es el mismo que /mes, por consistencia y para reutilizar código".